### PR TITLE
ignore mesages with data = ""

### DIFF
--- a/packages/iframe-channel-provider/src/channel-provider.ts
+++ b/packages/iframe-channel-provider/src/channel-provider.ts
@@ -189,6 +189,7 @@ export class IFrameChannelProvider implements IFrameChannelProviderInterface {
 
   protected async onMessage(event: MessageEvent) {
     let message;
+    if (event.data == '') return;
     if (isJsonRpcNotification(event.data)) {
       message = parseNotification(event.data); // Narrows type, throws if it does not fit the schema
       const notificationMethod = message.method;


### PR DESCRIPTION
- I am not sure why we get these messages
- the resulting error is fixed in an upstream version of the package (thru dependence on client-api-schema, where bug was fixed)
- this seems like a very harmless workaround for now