### PR TITLE
move @statechannels/iframe-channel-provider from prod to dev dependency

### DIFF
--- a/packages/channel-client/package.json
+++ b/packages/channel-client/package.json
@@ -5,12 +5,12 @@
   "author": "snario <liam@l4v.io>",
   "dependencies": {
     "@statechannels/client-api-schema": "0.3.0",
-    "@statechannels/iframe-channel-provider": "0.3.0",
     "ethers": "4.0.45",
     "eventemitter3": "4.0.0",
     "loglevel": "1.6.8"
   },
   "devDependencies": {
+    "@statechannels/iframe-channel-provider": "0.3.0",
     "@microsoft/api-extractor": "^7.9.2",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",


### PR DESCRIPTION
we only import the interface, not any runtime code